### PR TITLE
Update guess labels in Game View + Reset Game UI 

### DIFF
--- a/src/app/Main.java
+++ b/src/app/Main.java
@@ -51,6 +51,13 @@ public class Main {
         EndView endView = EndViewFactory.create(viewManagerModel, leaderboardViewModel, chooseViewModel, leaderboardDataAccessInterface);
         views.add(endView, endView.viewName);
 
+        // When "Play Again" button is clicked in EndView, GameView resets state
+        endView.addPropertyChangeListener(evt -> {
+            if ("gameReset".equals(evt.getPropertyName())) {
+                gameView.resetGame();
+            }
+        });
+
 
         application.setSize(600, 800);
         application.setVisible(true);

--- a/src/view/EndView.java
+++ b/src/view/EndView.java
@@ -60,6 +60,14 @@ public class EndView extends JPanel implements ActionListener, PropertyChangeLis
         this.add(playAgain);
         this.add(leaderboard);
         this.setVisible(true);
+
+        playAgain.addActionListener(new ActionListener() {
+            public void actionPerformed(ActionEvent e) {
+                playAgainController.execute();
+                firePropertyChange("gameReset", false, true);
+            }
+        });
+
     }
 
     @Override

--- a/src/view/GameView.java
+++ b/src/view/GameView.java
@@ -125,16 +125,6 @@ public class GameView extends JPanel implements PropertyChangeListener {
         Dimension maxSize = new Dimension(Short.MAX_VALUE, 150); // Maximum size
         centerPanel.add(new Box.Filler(minSize, prefSize, maxSize));
 
-        // Set up for progress bar
-//        JPanel progressBarPanel = new JPanel();
-//        progressBarPanel.setLayout(new BoxLayout(progressBarPanel, BoxLayout.Y_AXIS));
-//        progressBarPanel.setBackground(Color.BLACK);
-//
-//        // Add progress bar to its panel
-//        JProgressBar progressBar = new JProgressBar(0, 1);
-//        progressBar.setForeground(Color.GREEN);
-//        progressBarPanel.add(progressBar);
-
         playButton = new JButton("Play");
         skipButton = new JButton("Skip");
         submitButton = new JButton("Submit");
@@ -145,8 +135,6 @@ public class GameView extends JPanel implements PropertyChangeListener {
         buttonPanel.add(submitButton);
         buttonPanel.setBackground(Color.BLACK);
         this.add(buttonPanel, BorderLayout.SOUTH);
-        // this.add(progressBarPanel, BorderLayout.AFTER_LAST_LINE); // adds the progress bar panel just below the button panel
-
 
         searchTextField.addKeyListener(
                 new KeyListener() {
@@ -233,7 +221,6 @@ public class GameView extends JPanel implements PropertyChangeListener {
                 }
                 Track song = currentState.getCurrentSong();
                 System.out.println("correct answer: " + song.toString());
-                // song.getArtist() + " - " + song.getTitle()
                 guessController.execute(song.toString(), guess, currentState.getGuesses(), currentState.getMaxGuesses());
             }
         });
@@ -267,6 +254,21 @@ public class GameView extends JPanel implements PropertyChangeListener {
         resultList.setModel(model);
     }
 
+    /* Reset the game once play again is selected from end view */
+    public void resetGame() {
+        resetGuessLabels();
+        resetSearchBar();
+    }
+    public void resetGuessLabels() {
+        for (JLabel label : guessLabels) {
+            label.setText("");
+        }
+    }
+
+    public void resetSearchBar() {
+        searchTextField.setText("");
+        resultList.setModel(new DefaultListModel<>());
+    }
 
     public void propertyChange(PropertyChangeEvent evt) {
         if (evt.getNewValue() instanceof SearchBarState) {
@@ -275,6 +277,7 @@ public class GameView extends JPanel implements PropertyChangeListener {
             updateSearchResults(tracks);
         }
     }
+
 
     public static void main(String[] args) {
         javax.swing.SwingUtilities.invokeLater(new Runnable() {

--- a/src/view/GameView.java
+++ b/src/view/GameView.java
@@ -1,12 +1,16 @@
 package view;
 
+import app.GameUseCaseFactory;
 import entity.Track;
 import interface_adapter.PlaySong.PlayController;
+import interface_adapter.PlaySong.PlayViewModel;
+import interface_adapter.ViewManagerModel;
 import interface_adapter.choose_genre.ChooseState;
 import interface_adapter.choose_genre.ChooseViewModel;
 import interface_adapter.guess.GuessController;
 import interface_adapter.guess.GuessState;
 import interface_adapter.guess.GuessViewModel;
+import interface_adapter.leaderboard.LeaderboardViewModel;
 import interface_adapter.search_bar.SearchBarController;
 import interface_adapter.search_bar.SearchBarState;
 import interface_adapter.search_bar.SearchBarViewModel;
@@ -57,6 +61,7 @@ public class GameView extends JPanel implements PropertyChangeListener {
         Font font = new Font("SansSerif", Font.PLAIN, 16); // Choose the desired font and size
         this.setFont(font);
 
+        /* Setup for SEARCH PANEL */
         JPanel searchPanel = new JPanel(new BorderLayout());
         searchPanel.setBackground(Color.BLACK); // Set the background color to match the frame
 
@@ -67,15 +72,15 @@ public class GameView extends JPanel implements PropertyChangeListener {
         searchTextField = new JTextField();
         searchTextField.setForeground(Color.WHITE);
         searchTextField.setBackground(Color.BLACK);
-        Font searchTextFont = new Font("SansSerif", Font.PLAIN, 18); // Choose the desired font and size
+        Font searchTextFont = new Font("Sans Serif", Font.PLAIN, 18); // Choose the desired font and size
         searchTextField.setFont(searchTextFont);
         searchTextField.setBorder(BorderFactory.createLineBorder(Color.LIGHT_GRAY, 2));
+        searchTextField.setPreferredSize(new Dimension(this.getWidth(), 30)); // Adjust the height as needed
 
         searchPanel.add(searchTextField, BorderLayout.CENTER);
         this.add(searchPanel, BorderLayout.NORTH);
-        // this.add(searchTextField, BorderLayout.NORTH);
 
-        // Setup for centerPanel
+        /* Setup for CENTER PANEL */
         centerPanel = new JPanel();
         centerPanel.setLayout(new BoxLayout(centerPanel, BoxLayout.Y_AXIS));
         centerPanel.setBackground(Color.BLACK);
@@ -109,7 +114,6 @@ public class GameView extends JPanel implements PropertyChangeListener {
 
             // Initialize each label and add it to the corresponding panel
             guessLabels[i] = new JLabel("");
-            // TODO: Set font and size (resultFont should be sufficient?)
             guessLabels[i].setForeground(Color.BLACK);
             guessRectangles[i].add(guessLabels[i]);
         }
@@ -121,10 +125,15 @@ public class GameView extends JPanel implements PropertyChangeListener {
         Dimension maxSize = new Dimension(Short.MAX_VALUE, 150); // Maximum size
         centerPanel.add(new Box.Filler(minSize, prefSize, maxSize));
 
-        // TODO: Include progress bar (or at least something to track progression of song / number of guesses)
-        JProgressBar progressBar = new JProgressBar(0, 1);
-        progressBar.setForeground(Color.GREEN);
-        centerPanel.add(progressBar);
+        // Set up for progress bar
+//        JPanel progressBarPanel = new JPanel();
+//        progressBarPanel.setLayout(new BoxLayout(progressBarPanel, BoxLayout.Y_AXIS));
+//        progressBarPanel.setBackground(Color.BLACK);
+//
+//        // Add progress bar to its panel
+//        JProgressBar progressBar = new JProgressBar(0, 1);
+//        progressBar.setForeground(Color.GREEN);
+//        progressBarPanel.add(progressBar);
 
         playButton = new JButton("Play");
         skipButton = new JButton("Skip");
@@ -136,6 +145,7 @@ public class GameView extends JPanel implements PropertyChangeListener {
         buttonPanel.add(submitButton);
         buttonPanel.setBackground(Color.BLACK);
         this.add(buttonPanel, BorderLayout.SOUTH);
+        // this.add(progressBarPanel, BorderLayout.AFTER_LAST_LINE); // adds the progress bar panel just below the button panel
 
 
         searchTextField.addKeyListener(
@@ -167,29 +177,38 @@ public class GameView extends JPanel implements PropertyChangeListener {
             public void mouseClicked(MouseEvent evt) {
                 String selectedTrack = resultList.getSelectedValue();
                 searchTextField.setText(selectedTrack);
-                // Play track here
             }
         });
 
         skipButton.addActionListener(new ActionListener() {
             public void actionPerformed(ActionEvent e) {
                 GuessState currentState = guessViewModel.getState();
-                skipController.execute(currentState.getCurrentSong().getTitle(), currentState.getGuesses(), currentState.getMaxGuesses());                // make sure to update guess label
+                int currentGuessIndex = currentState.getGuesses() - 1;
+
+                // Update guess label to "Skipped"
+                if (currentGuessIndex >= 0 && currentGuessIndex < guessLabels.length) {
+                    guessLabels[currentGuessIndex].setText("Skipped");
+                    guessLabels[currentGuessIndex].setForeground(Color.GRAY);
+
+                    guessLabels[currentGuessIndex].revalidate();
+                    guessLabels[currentGuessIndex].repaint();
+                }
+
+                skipController.execute(currentState.getCurrentSong().getTitle(), currentState.getGuesses(), currentState.getMaxGuesses());
             }
         });
 
         playButton.addActionListener(new ActionListener() {
             public void actionPerformed(ActionEvent e) {
                 GuessState currentGuessState = guessViewModel.getState();
-                // make sure to update guess label
+                // Update guess label
 
-                if(currentGuessState.getGuesses()<6){
+                if (currentGuessState.getGuesses() < 6) {
                     ChooseState currentChooseState = chooseViewModel.getState();
-                    //System.out.println(currentChooseState.getTrack().getTitle());
-                    progressBar.setMinimum(0);
-                    progressBar.setMaximum(currentGuessState.getGuesses()*300);
-                    Thread progressThread = new ProgressThread(progressBar);
-                    progressThread.start();
+//                    progressBar.setMinimum(0);
+//                    progressBar.setMaximum(currentGuessState.getGuesses()*300);
+//                    Thread progressThread = new ProgressThread(progressBar);
+//                    progressThread.start();
 
                     playController.execute(currentChooseState.getTrack(), currentGuessState.getGuesses());
 
@@ -201,16 +220,21 @@ public class GameView extends JPanel implements PropertyChangeListener {
         submitButton.addActionListener(new ActionListener() {
             public void actionPerformed(ActionEvent e) {
                 GuessState currentState = guessViewModel.getState();
-                String guess = (String)resultList.getSelectedValue();
-                System.out.println(guess);
+                String guess = resultList.getSelectedValue();
                 currentState.setGuess(guess);
-                int i = currentState.getGuesses()-1;
-                guessLabels[i] = new JLabel(guess);
-                guessLabels[i].setFont(resultFont);
-                guessLabels[i].setForeground(Color.BLACK);
+                System.out.println("guess: " + guess);
+                int currentGuessIndex = currentState.getGuesses() - 1;
+                if (currentGuessIndex >= 0 && currentGuessIndex < guessLabels.length) {
+                    guessLabels[currentGuessIndex].setText("❌ " + guess.toString());
+                    guessLabels[currentGuessIndex].setForeground(Color.RED);
+
+                    guessLabels[currentGuessIndex].revalidate();
+                    guessLabels[currentGuessIndex].repaint();
+                }
                 Track song = currentState.getCurrentSong();
-                System.out.println(song.getArtist() + " - " + song.getTitle());
-                guessController.execute(song.getArtist() + " - " + song.getTitle(), guess, currentState.getGuesses(), currentState.getMaxGuesses());
+                System.out.println("correct answer: " + song.toString());
+                // song.getArtist() + " - " + song.getTitle()
+                guessController.execute(song.toString(), guess, currentState.getGuesses(), currentState.getMaxGuesses());
             }
         });
 
@@ -227,7 +251,6 @@ public class GameView extends JPanel implements PropertyChangeListener {
         // call search controller with the query
         searchBarController.execute(query);
 
-        // searchBarViewModel.getState().setCurrentSearchQuery(query);
         // Trigger search in ViewModel
         List<Track> tracks = searchBarViewModel.getState().getTracks();
         updateSearchResults(tracks); // Update Jlist Model
@@ -253,26 +276,32 @@ public class GameView extends JPanel implements PropertyChangeListener {
         }
     }
 
+    public static void main(String[] args) {
+        javax.swing.SwingUtilities.invokeLater(new Runnable() {
+            public void run() {
+                // Create and set up the window.
+                JFrame frame = new JFrame("Game View Test");
+                frame.setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
 
-}
-class ProgressThread extends Thread{
-    private JProgressBar progressBar;
-    public ProgressThread(JProgressBar progressBar){
-        this.progressBar = progressBar;
-    }
-    public void run(){
-        try{
-            int j = 0;
-            while (j <= progressBar.getMaximum()) {
-                j += 10;
-                // fill the menu bar
-                progressBar.setValue(j);
-                Thread.sleep(100);
+                // Create and set up the content pane.
+                ChooseViewModel chooseViewModel = new ChooseViewModel();
+                LeaderboardViewModel leaderboardViewModel = new LeaderboardViewModel();
+                GuessViewModel guessViewModel = new GuessViewModel();
+                SearchBarViewModel searchBarViewModel = new SearchBarViewModel();
+                PlayViewModel playViewModel = new PlayViewModel();
+                ViewManagerModel viewManagerModel = new ViewManagerModel();
+
+                GameView newContentPane = GameUseCaseFactory.create(searchBarViewModel, guessViewModel, leaderboardViewModel, chooseViewModel, playViewModel, viewManagerModel);
+                newContentPane.setOpaque(true); //content panes must be opaque
+                frame.setContentPane(newContentPane);
+
+                // Display the window.
+                frame.pack();
+                frame.setVisible(true);
             }
-            progressBar.setValue(0);
-
-        } catch (InterruptedException e) {
-            throw new RuntimeException(e);
-        }
+        });
     }
+
 }
+
+


### PR DESCRIPTION
Implemented the feature where clicking on the "Skip" or "Submit" button updates the label of the guesses to either show the wrong guess or "Skipped". 

I also added logic to reset the Game UI once the user reaches the End View and wants to play again. This clears out all of the labels from the previous games and the search results back to its initial, clear state. 
